### PR TITLE
herokuにデプロイしたときのルートURLを追加

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,0 +1,5 @@
+class WelcomeController < ApplicationController
+  def index
+    render json: { message: 'welcome rails API' }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  root 'welcome#index'
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {


### PR DESCRIPTION
### 【実装内容】
rails側のherokuのアプリが正常にデプロイしたことを確認するため、ルートURLを追加しました。