### PR TITLE
Projectテーブルにおけるproject_imagesカラムをtextからjsonに変更

### DIFF
--- a/db/migrate/20230908125532_change_project_images_data_type.rb
+++ b/db/migrate/20230908125532_change_project_images_data_type.rb
@@ -1,0 +1,5 @@
+class ChangeProjectImagesDataType < ActiveRecord::Migration[7.0]
+  def change
+    change_column :projects, :project_images, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_091855) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_08_125532) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
### 【実装内容】
Projectテーブルのproject_imagesカラムのデータ型がtextになっており、画像の取得ができなかったため、jsonに変更しました。

開発環境ではjsonにデータ型を変更する本実装と同じマイグレーションファイルを作成していたはずですが、herokuでrials db:migrateをした際にjsonにならなかったので、なんらかの原因でそのファイルを削除してしまったものかと思われます。