### PR TITLE
ゲストユーザー作成時に必須のパスワード確認を指定していなかったためバリデーションに引っかかっていたので修正

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -3,6 +3,6 @@ class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsCon
   private
 
   def sign_up_params
-    params.permit(:name, :email, :password, :password_confirmation)
+    params.permit(:name, :email, :password, :password_confirmation, :profile)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,8 @@ class User < ActiveRecord::Base
 
   def self.guest
     find_or_create_by!(email: "guest@example.com") do |user|
-      user.password = SecureRandom.urlsafe_base64
+      user.password = 'guestpassword'
+      user.password_confirmation = 'guestpassword'
       user.name = 'ゲストユーザー'
       user.profile = 'ゲストユーザーです。よろしくお願いします。'
     end


### PR DESCRIPTION

【実装内容】
デプロイ後以下のバグ対応をしました。

・ゲストログインができない
初回はゲストログインユーザーが存在しない場合、新規作成される仕様ですが、その際のバリデーションに引っかかっていたので修正しました。